### PR TITLE
Add HMO and PPO Plan Pages with SEO Optimization

### DIFF
--- a/src/pages/health-insurance/aca/plans/hmo/index.tsx
+++ b/src/pages/health-insurance/aca/plans/hmo/index.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { NextSeo } from 'next-seo';
+import { PlanComparisonTool } from '@/components/plan-comparison/PlanComparisonTool';
+import { generatePageSEO, generateBusinessSchema } from '@/lib/seo-utils';
+
+const HMOPlansPage: React.FC = () => {
+  const pageTitle = 'HMO Health Insurance Plans';
+  const pageDescription = 'Comprehensive HMO health insurance plans with coordinated care and lower costs. Find the perfect plan for your healthcare needs.';
+  const pagePath = '/health-insurance/aca/plans/hmo';
+
+  const seoProps = generatePageSEO({
+    title: pageTitle,
+    description: pageDescription,
+    path: pagePath
+  });
+
+  const businessSchema = generateBusinessSchema();
+
+  const hmoPlanData = [
+    {
+      id: 'hmo-basic',
+      name: 'Basic HMO Plan',
+      monthlyPremium: 300,
+      deductible: 2000,
+      outOfPocketMax: 5500,
+      coverageDetails: {
+        preventiveCare: 'Fully Covered',
+        primaryCareCopay: '$20',
+        specialistVisit: '$40',
+        emergencyRoom: '$200',
+      },
+    },
+    {
+      id: 'hmo-premium',
+      name: 'Premium HMO Plan',
+      monthlyPremium: 450,
+      deductible: 1500,
+      outOfPocketMax: 4000,
+      coverageDetails: {
+        preventiveCare: 'Fully Covered',
+        primaryCareCopay: '$15',
+        specialistVisit: '$30',
+        emergencyRoom: '$150',
+      },
+    }
+  ];
+
+  return (
+    <>
+      <NextSeo {...seoProps} />
+      
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ 
+          __html: JSON.stringify([
+            businessSchema,
+            {
+              "@context": "https://schema.org",
+              "@type": "Product",
+              "name": "HMO Health Insurance Plans",
+              "description": pageDescription,
+              "offers": {
+                "@type": "Offer",
+                "priceCurrency": "USD",
+                "description": "Affordable HMO health insurance plans"
+              }
+            }
+          ])
+        }}
+      />
+
+      <div className="container mx-auto p-6">
+        <h1 className="text-3xl font-bold mb-6">HMO Health Insurance Plans</h1>
+        <PlanComparisonTool 
+          planType="HMO"
+          planData={hmoPlanData}
+          features={[
+            'Network Restrictions',
+            'Coordinated Care',
+            'Lower Costs',
+            'Primary Care Physician Referral'
+          ]}
+        />
+      </div>
+    </>
+  );
+};
+
+export default HMOPlansPage;

--- a/src/pages/health-insurance/aca/plans/ppo/index.tsx
+++ b/src/pages/health-insurance/aca/plans/ppo/index.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { NextSeo } from 'next-seo';
+import { PlanComparisonTool } from '@/components/plan-comparison/PlanComparisonTool';
+import { generatePageSEO, generateBusinessSchema } from '@/lib/seo-utils';
+
+const PPOPlansPage: React.FC = () => {
+  const pageTitle = 'PPO Health Insurance Plans';
+  const pageDescription = 'Flexible PPO health insurance plans with extensive provider networks. Choose your healthcare providers with comprehensive coverage.';
+  const pagePath = '/health-insurance/aca/plans/ppo';
+
+  const seoProps = generatePageSEO({
+    title: pageTitle,
+    description: pageDescription,
+    path: pagePath
+  });
+
+  const businessSchema = generateBusinessSchema();
+
+  const ppoPlanData = [
+    {
+      id: 'ppo-basic',
+      name: 'Basic PPO Plan',
+      monthlyPremium: 400,
+      deductible: 2500,
+      outOfPocketMax: 6500,
+      coverageDetails: {
+        preventiveCare: 'Fully Covered',
+        primaryCareCopay: '$30',
+        specialistVisit: '$60',
+        emergencyRoom: '$300',
+      },
+    },
+    {
+      id: 'ppo-premium',
+      name: 'Premium PPO Plan',
+      monthlyPremium: 600,
+      deductible: 1750,
+      outOfPocketMax: 5000,
+      coverageDetails: {
+        preventiveCare: 'Fully Covered',
+        primaryCareCopay: '$25',
+        specialistVisit: '$50',
+        emergencyRoom: '$250',
+      },
+    }
+  ];
+
+  return (
+    <>
+      <NextSeo {...seoProps} />
+      
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ 
+          __html: JSON.stringify([
+            businessSchema,
+            {
+              "@context": "https://schema.org",
+              "@type": "Product",
+              "name": "PPO Health Insurance Plans",
+              "description": pageDescription,
+              "offers": {
+                "@type": "Offer",
+                "priceCurrency": "USD",
+                "description": "Comprehensive PPO health insurance plans"
+              }
+            }
+          ])
+        }}
+      />
+
+      <div className="container mx-auto p-6">
+        <h1 className="text-3xl font-bold mb-6">PPO Health Insurance Plans</h1>
+        <PlanComparisonTool 
+          planType="PPO"
+          planData={ppoPlanData}
+          features={[
+            'Flexible Network',
+            'No Referral Needed',
+            'Out-of-Network Coverage',
+            'More Provider Choices'
+          ]}
+        />
+      </div>
+    </>
+  );
+};
+
+export default PPOPlansPage;


### PR DESCRIPTION
This PR adds two new pages for ACA health insurance plans:

## HMO Plans Page
- Comprehensive SEO optimization
- Dynamic plan comparison tool
- Structured data markup
- Detailed plan information

## PPO Plans Page
- Comprehensive SEO optimization
- Dynamic plan comparison tool
- Structured data markup
- Detailed plan information

### SEO Enhancements
- Page titles and descriptions
- Structured JSON-LD schemas
- Metadata for search engines

### Next Steps
- Add remaining Medicare-specific plan pages
- Further refine SEO strategies