### PR TITLE
Add E2E Testing Infrastructure

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { PlaywrightTestConfig, devices } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  testDir: './e2e',
+  timeout: 30000,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    trace: 'on-first-retry',
+    baseURL: process.env.TEST_BASE_URL || 'http://localhost:3000',
+  },
+  projects: [
+    {
+      name: 'Desktop Chrome',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    },
+  ],
+};
+
+export default config;


### PR DESCRIPTION
This PR adds E2E testing infrastructure using Playwright.

Changes include:
- Playwright configuration setup
- Basic navigation tests
- Insurance tools tests
- GitHub Actions workflow for automated testing

Testing Instructions:
1. Install dependencies: `npm install`
2. Install Playwright: `npx playwright install`
3. Run tests: `npx playwright test`

Please review the test coverage and suggest any additional test cases that might be valuable.